### PR TITLE
Some fixes

### DIFF
--- a/tactile.lua
+++ b/tactile.lua
@@ -76,18 +76,30 @@ function Control:getValue()
 end
 
 function Control:isDown(dir)
-  local value = self._currentValue
-  return dir and sign(value) == sign(dir) or value ~= 0
+  if dir then
+    return sign(self._currentValue) == sign(dir)
+  end
+  return self._currentValue ~= 0
 end
 
 function Control:pressed(dir)
-  return dir and sign(self._currentValue) == sign(dir)
-    or self._previousValue == 0 and self._currentValue ~= 0
+  if dir then
+    dir = sign(dir)
+    return sign(self._currentValue) == dir
+      and sign(self._previousValue) ~= dir
+  end
+  return self._currentValue ~= 0
+    and self._previousValue == 0
 end
 
 function Control:released(dir)
-  return dir and sign(self._previousValue) == sign(dir)
-    or self._previousValue ~= 0 and self._currentValue == 0
+  if dir then
+    dir = sign(dir)
+    return sign(self._currentValue) ~= dir
+      and sign(self._previousValue) == dir
+  end
+  return self._currentValue == 0
+    and self._previousValue ~= 0
 end
 
 function Control:update()

--- a/tactile.lua
+++ b/tactile.lua
@@ -76,18 +76,18 @@ function Control:getValue()
 end
 
 function Control:isDown(dir)
-  local value = self:getValue()
+  local value = self._currentValue
   return dir and sign(value) == sign(dir) or value ~= 0
 end
 
 function Control:pressed(dir)
   return dir and sign(self._currentValue) == sign(dir)
-    or not (self._currentValue == 0 or self._previousValue ~= 0)
+    or self._previousValue == 0 and self._currentValue ~= 0
 end
 
 function Control:released(dir)
   return dir and sign(self._previousValue) == sign(dir)
-    or not (self._previousValue == 0 or self._currentValue ~= 0)
+    or self._previousValue ~= 0 and self._currentValue == 0
 end
 
 function Control:update()

--- a/tactile.lua
+++ b/tactile.lua
@@ -142,7 +142,8 @@ function tactile.gamepadButtons(num, ...)
       'GamepadButton (string)')
   end
   return function()
-    return love.joystick.getJoysticks()[num]:isGamepadDown(unpack(buttons))
+    local joystick = love.joystick.getJoysticks()[num]
+    return joystick ~= nil and joystick:isGamepadDown(unpack(buttons))
   end
 end
 
@@ -150,7 +151,8 @@ function tactile.gamepadAxis(num, axis)
   verify('tactile.gamepadAxis()', 1, num, 'number')
   verify('tactile.gamepadAxis()', 2, axis, 'string', 'GamepadAxis (string)')
   return function()
-    return love.joystick.getJoysticks()[num]:getGamepadAxis(axis)
+    local joystick = love.joystick.getJoysticks()[num]
+    return joystick ~= nil and joystick:getGamepadAxis(axis) or 0
   end
 end
 


### PR DESCRIPTION
1. `pressed` and `released` with a `dir` argument now check the previous value so that they work as intended. Hope I understand the intended behavior correctly though.
2. `pressed`, `released` and `isDown` now return `false` instead of a result of the non-dir check when `dir` is provided and the condition is false.
3. `gamepadButtons` and `gamepadAxis` now ensure that a joystick with the given number exists before doing anything with it to avoid a blue screen when the joystick is not available.
